### PR TITLE
Fix: expected getStatus to be a string, but got null

### DIFF
--- a/src/Entity/Contact.php
+++ b/src/Entity/Contact.php
@@ -157,7 +157,7 @@ class Contact
      */
     public function getStatus(): string
     {
-        return $this->status;
+        return $this->status ? $this->status : '';
     }
 
     /**


### PR DESCRIPTION
I encountered this issue while doing a simple createContact